### PR TITLE
Improve speed of browsing in filelist

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -309,7 +309,14 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
         $folderIdentifier = $this->canonicalizeAndCheckFolderIdentifier($folderIdentifier);
         $path = $this->getStreamWrapperPath($folderIdentifier);
 
+        if ($deleteRecursively) {
+            $foldersInFolder = $this->resolveFolderEntries($folderIdentifier, true, false, true);
+
+            array_map(array($this, 'deleteFolder'), $foldersInFolder);
+        }
+
         $this->flushCacheEntriesForFolder($folderIdentifier);
+        $this->flushCacheEntriesForFolder(dirname($folderIdentifier));
 
         return unlink($path);
     }

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -575,6 +575,10 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
             $oldEntryPath = $this->getStreamWrapperPath($oldEntryIdentifier);
             $newEntryPath = $this->getStreamWrapperPath($newEntryIdentifier);
 
+            if (is_dir($oldEntryPath)) {
+                $this->flushCacheEntriesForFolder($oldEntryIdentifier);
+            }
+
             rename($oldEntryPath, $newEntryPath);
 
             $renamedEntries[$oldEntryIdentifier] = $newEntryIdentifier;
@@ -584,6 +588,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
 
         $renamedEntries[$sourceFolderIdentifier] = $targetFolderIdentifier;
 
+        $this->flushCacheEntriesForFolder($sourceFolderIdentifier);
         $this->flushCacheEntriesForFolder(dirname($sourceFolderIdentifier));
         $this->flushCacheEntriesForFolder(dirname($targetFolderIdentifier));
 

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -403,9 +403,14 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
     {
         $parentFolderIdentifier = $this->canonicalizeAndCheckFolderIdentifier($parentFolderIdentifier);
         $targetFileIdentifier = rtrim($parentFolderIdentifier, '/') . $this->canonicalizeAndCheckFileIdentifier($fileName);
-        $targetFilePath = $this->getStreamWrapperPath($targetFileIdentifier);
 
-        file_put_contents($targetFilePath, '');
+        // create an empty file using the putObject method instead of the wrapper
+        // file_put_contents() without data or touch() yield unexpected results
+        $this->s3Client->putObject(array(
+            'Bucket' => $this->configuration['bucket'],
+            'Key' => ltrim($targetFileIdentifier, '/'),
+            'Body' => ''
+        ));
 
         $this->flushCacheEntriesForFolder($parentFolderIdentifier);
 

--- a/Classes/Driver/Cache.php
+++ b/Classes/Driver/Cache.php
@@ -44,6 +44,7 @@ class Cache extends Aws\LruArrayCache
      */
     public function get($key)
     {
+        $key = rtrim($key, '/');
         $cacheFrontend = self::getCacheFrontend();
         $entryIdentifier = self::buildEntryIdentifier($key);
 
@@ -68,6 +69,7 @@ class Cache extends Aws\LruArrayCache
      */
     public function set($key, $value, $ttl = 0)
     {
+        $key = rtrim($key, '/');
         $cacheFrontend = self::getCacheFrontend();
         $entryIdentifier = self::buildEntryIdentifier($key);
 
@@ -85,6 +87,7 @@ class Cache extends Aws\LruArrayCache
      */
     public function remove($key)
     {
+        $key = rtrim($key, '/');
         $cacheFrontend = self::getCacheFrontend();
         $entryIdentifier = self::buildEntryIdentifier($key);
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "typo3/cms-core": ">=6.2.12, <7.6.99",
+        "typo3/cms-core": ">=6.2.12, <=8",
         "aws/aws-sdk-php": "^3.2.3"
     }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -58,7 +58,7 @@ if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations
 }
 
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['backend'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\SimpleFileBackend';
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\FileBackend';
 }
 
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['frontend'])) {


### PR DESCRIPTION
This patch implements a full result cache on the `resolveFolderEntries` action. The result of this action is used to get a count of items and check if a folder contains subfolders (access to it is frequent).

Compared to uploading actual new files or creating the folders users like to read fast. This is what this patch aims to do. Directory listings are pretty static, and as soon a file is added the cache for that particular folder is flushed.

Targeted flushing is implemented in an attempt to prevent constant flushing and rebuilding of the whole file set if different users choose to update all their folders. By default the `File` backend is used since it supports TTL and tagging, but when used in a production setup you should consider `Redis` or some other alternative that doesn't hurt the file system.