### PR TITLE
Improve performance of cache entry fetching

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -710,6 +710,10 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
      */
     public function getFileForLocalProcessing($fileIdentifier, $writable = true)
     {
+        if (isset($this->temporaryFiles[$fileIdentifier])) {
+            return $this->temporaryFiles[$fileIdentifier];
+        }
+
         $fileIdentifier = $this->canonicalizeAndCheckFileIdentifier($fileIdentifier);
         $temporaryFilePath = $this->getTemporaryPathForFile($fileIdentifier);
         $path = $this->getStreamWrapperPath($fileIdentifier);
@@ -717,7 +721,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
         copy($path, $temporaryFilePath);
 
         if (!$writable) {
-            $this->temporaryFiles[] = $temporaryFilePath;
+            $this->temporaryFiles[$fileIdentifier] = $temporaryFilePath;
         }
 
         return $temporaryFilePath;
@@ -1015,8 +1019,8 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
             'ls'
         );
 
-        if ($cacheFrontend->has($cacheEntryIdentifier)) {
-            return $cacheFrontend->get($cacheEntryIdentifier);
+        if ($folderEntries = $cacheFrontend->get($cacheEntryIdentifier)) {
+            return $folderEntries;
         }
 
         $iteratorMode = \FilesystemIterator::UNIX_PATHS |

--- a/Classes/Driver/Cache.php
+++ b/Classes/Driver/Cache.php
@@ -110,26 +110,9 @@ class Cache extends Aws\LruArrayCache
      */
     public static function getCacheFrontend()
     {
-        $cacheManager = Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Cache\\CacheManager');
-
-        if (self::$cacheFrontend === null
-            && is_array($GLOBALS['TYPO3_CONF_VARS']) && array_key_exists('SYS', $GLOBALS['TYPO3_CONF_VARS'])
-            && is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']) && array_key_exists('caching', $GLOBALS['TYPO3_CONF_VARS']['SYS'])
-            && is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching'])
-            && array_key_exists('cacheConfigurations', $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching'])
-            && is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'])
-            && array_key_exists('tx_fal_s3', $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'])
-            && $cacheManager instanceof Core\Cache\CacheManager
-        ) {
-            $cacheManager->setCacheConfigurations(array(
-                'tx_fal_s3' => $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']
-            ));
+        if (self::$cacheFrontend === null && !empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3'])) {
+            self::$cacheFrontend = Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Cache\\CacheManager')->getCache('tx_fal_s3');
         }
-
-        if ($cacheManager instanceof Core\Cache\CacheManager && $cacheManager->hasCache('tx_fal_s3')) {
-            self::$cacheFrontend = $cacheManager->getCache('tx_fal_s3');
-        }
-
         return self::$cacheFrontend;
     }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -53,9 +53,6 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['deployer']['configuration']['FalS3.yaml'
 );
 
 // Register cache 'tx_fal_s3'
-if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['options'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['options'] = array();
-}
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['groups'])) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['groups'] = array(
         'system'

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -53,24 +53,11 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['deployer']['configuration']['FalS3.yaml'
 );
 
 // Register cache 'tx_fal_s3'
-if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3'] = array();
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['options'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['options'] = array();
 }
-
-if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['backend'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\FileBackend';
-}
-
-if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['frontend'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['frontend'] = 'TYPO3\\CMS\\Core\\Cache\\Frontend\\VariableFrontend';
-}
-
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['groups'])) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['groups'] = array(
         'system'
     );
-}
-
-if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['options'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['options'] = array();
 }


### PR DESCRIPTION
Calling cache->has has significant overhead, with no real benefit.
Instead we can just fetch the cache entry and if it does not
exist, proceed with generating the payload.