### PR TITLE
[BUGFIX] Correctly recurse directories even when only files are requested

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1030,9 +1030,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
             function(\SplFileInfo $fileInfo) use ($excludedFolders) {
                 return ($fileInfo->getFilename() === '')
                     || ($fileInfo->isDir() && in_array($fileInfo->getFilename(), $excludedFolders, true));
-            },
-            $includeFiles,
-            $includeDirectories
+            }
         );
 
         if ($recursive) {
@@ -1049,6 +1047,13 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
         while ($iterator->valid()) {
             $entry = $iterator->current();
             $directoryEntries[$entry] = $entry;
+            $isDirectory = substr($entry, -1) === '/';
+            if ($isDirectory && !$includeDirectories) {
+                unset($directoryEntries[$entry]);
+            }
+            if (!$isDirectory && !$includeFiles) {
+                unset($directoryEntries[$entry]);
+            }
             $iterator->next();
         }
 

--- a/Classes/Driver/CachedDirectoryIterator.php
+++ b/Classes/Driver/CachedDirectoryIterator.php
@@ -39,16 +39,6 @@ class CachedDirectoryIterator implements \RecursiveIterator, \SeekableIterator
     private $normalizer;
 
     /**
-     * @var bool
-     */
-    private $includeFiles;
-
-    /**
-     * @var bool
-     */
-    private $includeDirectories;
-
-    /**
      * @var callable
      */
     private $filter;
@@ -68,17 +58,13 @@ class CachedDirectoryIterator implements \RecursiveIterator, \SeekableIterator
         $iteratorMode,
         FrontendInterface $cache,
         callable $normalizer,
-        callable $filter,
-        $includeFiles = true,
-        $includeDirectories = true
+        callable $filter
     ) {
         $this->path = $path;
         $this->iteratorMode = $iteratorMode;
         $this->cache = $cache;
         $this->normalizer = $normalizer;
         $this->filter = $filter;
-        $this->includeFiles = $includeFiles;
-        $this->includeDirectories = $includeDirectories;
         $this->initialize();
     }
 
@@ -102,15 +88,6 @@ class CachedDirectoryIterator implements \RecursiveIterator, \SeekableIterator
             $cacheTags = [Cache::buildEntryIdentifier($this->path, 'd')];
             $this->cache->set($cacheEntryIdentifier, $this->filesAndFolders, $cacheTags, 0);
         }
-        $this->filesAndFolders = $this->getFileOrFoldersFromCacheEntry($this->filesAndFolders, $this->includeFiles, $this->includeDirectories);
-    }
-
-    private function getFileOrFoldersFromCacheEntry(array $cacheEntries, $includeFiles = true, $includeDirectories = true)
-    {
-        return array_values(array_filter($cacheEntries, function($identifier) use ($includeFiles, $includeDirectories) {
-            $isDirectory = substr($identifier, -1) === '/';
-            return ($isDirectory && $includeDirectories) || (!$isDirectory && $includeFiles);
-        }));
     }
 
     public function seek($position)
@@ -140,7 +117,7 @@ class CachedDirectoryIterator implements \RecursiveIterator, \SeekableIterator
 
     public function getChildren()
     {
-        return new self($this->path . basename($this->filesAndFolders[$this->currentIndex]) . '/', $this->iteratorMode, $this->cache, $this->normalizer, $this->filter, $this->includeFiles, $this->includeDirectories);
+        return new self($this->path . basename($this->filesAndFolders[$this->currentIndex]) . '/', $this->iteratorMode, $this->cache, $this->normalizer, $this->filter);
     }
 
     public function key()


### PR DESCRIPTION
We move the check which type of entries should be returned out of the iterator
into the driver, so that the iterator correctly finds children (directories)

Fixes: #21