### PR TITLE
Fixed the sorting in the FileList and fixed the wrong modification time

### DIFF
--- a/Classes/Resource/File.php
+++ b/Classes/Resource/File.php
@@ -1,0 +1,27 @@
+<?php
+namespace MaxServ\FalS3\Resource;
+
+/**
+ * Class File
+ * @package MaxServ\FalS3\Resource
+ */
+class File extends \TYPO3\CMS\Core\Resource\File
+{
+    /**
+     * Returns the date (as UNIX timestamp) the file was last modified.
+     *
+     * @throws \RuntimeException
+     * @return int
+     */
+    public function getModificationTime()
+    {
+        if ($this->deleted) {
+            throw new \RuntimeException('File has been deleted.', 1329821488);
+        }
+        if ($this->storage->getDriverType() === 'MaxServ.FalS3') {
+            $fileInfo = $this->storage->getFileInfoByIdentifier($this->identifier);
+            return $fileInfo['mtime'];
+        }
+        return (int)$this->getProperty('modification_date');
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -55,6 +55,10 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['deployer']['configuration']['FalS3.yaml'
     'loader' => 'MaxServ\\FalS3\\Configuration\\ConfigurationLoader'
 );
 
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Core\Resource\File::class] = [
+    'className' => \MaxServ\FalS3\Resource\File::class
+];
+
 // Register cache 'tx_fal_s3'
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['groups'])) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3']['groups'] = array(


### PR DESCRIPTION
The sorting wasn't working properly in the backend so I changed the sorting.
It works, but I'm not really proud of the code so if anyone has improvements feel free!

What I changed:
- The function sortFolderEntries with a switch statement and a bunch of usorts.
- Xclass on Core/Resource/File because the modification time wasn't coming from the storage (but the FAL object?). Not sure if this is the nicest way but it seems to be working.