### PR TITLE
[FEATURE] - Update remote Cache-Control directives.

### DIFF
--- a/Classes/CacheControl/RemoteObjectUpdater.php
+++ b/Classes/CacheControl/RemoteObjectUpdater.php
@@ -1,0 +1,151 @@
+<?php
+namespace MaxServ\FalS3\CacheControl;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Aws;
+use MaxServ\FalS3;
+use TYPO3\CMS\Core;
+
+/**
+ * Class RemoteObjectUpdater
+ * @package MaxServ\FalS3\CacheControl
+ */
+class RemoteObjectUpdater
+{
+    /**
+     * Update the dimension of an image directly after creation
+     *
+     * @param array $data
+     *
+     * @return void
+     */
+    public function onLocalMetadataRecordUpdatedOrCreated(array $data)
+    {
+        $file = null;
+
+        try {
+            $file = Core\Resource\ResourceFactory::getInstance()->getFileObject(
+                $data['file']
+            );
+        } catch (\Exception $e) {
+            $file = null;
+        }
+
+        if ($file->getStorage()->getDriverType() !== FalS3\Driver\AmazonS3Driver::DRIVER_KEY) {
+            return;
+        }
+
+        $this->updateCacheControlDirectivesForRemoteObject($file);
+
+        if ($file instanceof Core\Resource\File) {
+            $processedFileRepository = Core\Utility\GeneralUtility::makeInstance(
+                Core\Resource\ProcessedFileRepository::class
+            );
+            if ($processedFileRepository instanceof Core\Resource\ProcessedFileRepository) {
+                $processedFiles = $processedFileRepository->findAllByOriginalFile($file);
+                array_walk(
+                    $processedFiles,
+                    function (Core\Resource\ProcessedFile $processedFile) {
+                        $this->updateCacheControlDirectivesForRemoteObject($processedFile);
+                    }
+                );
+            }
+
+        }
+    }
+
+    /**
+     * If a processed file is created (eg. a thumbnail) update the remote metadata.
+     *
+     * Because this method can be invoked without updating the actual file check
+     * the modification time of the remote object. Triggering an index for FAL and
+     * using the method above will force updating regardless of the modification time.
+     *
+     * @param Core\Resource\Service\FileProcessingService $fileProcessingService
+     * @param Core\Resource\Driver\DriverInterface $driver
+     * @param Core\Resource\ProcessedFile $processedFile
+     * @param Core\Resource\FileInterface $fileObject
+     * @param string $taskType
+     * @param array $configuration
+     * @return void
+     */
+    public function onPostFileProcess(
+        Core\Resource\Service\FileProcessingService $fileProcessingService,
+        Core\Resource\Driver\DriverInterface $driver,
+        Core\Resource\ProcessedFile $processedFile,
+        Core\Resource\FileInterface $fileObject,
+        $taskType,
+        array $configuration
+    ) {
+        $fileInfo = $driver->getFileInfoByIdentifier($processedFile->getIdentifier());
+
+        if (is_array($fileInfo)
+            && array_key_exists('mtime', $fileInfo)
+            && (int) $fileInfo['mtime'] > (time() - 30)
+        ) {
+            $this->updateCacheControlDirectivesForRemoteObject($processedFile);
+        }
+    }
+
+    /**
+     * @param Core\Resource\AbstractFile $file
+     *
+     * @return void
+     */
+    protected function updateCacheControlDirectivesForRemoteObject(Core\Resource\AbstractFile $file)
+    {
+        $cacheControl = null;
+        $currentResource = null;
+
+        $client = FalS3\Utility\RemoteObjectUtility::resolveClientForStorage($file->getStorage());
+        $driverConfiguration = FalS3\Utility\RemoteObjectUtility::resolveDriverConfigurationForStorage($file->getStorage());
+        $key = ltrim($file->getIdentifier(), '/');
+
+        if (is_array($driverConfiguration)
+            && array_key_exists('bucket', $driverConfiguration)
+            && $client instanceof Aws\S3\S3Client
+        ) {
+            $currentResource = $client->headObject(array(
+                'Bucket' => $driverConfiguration['bucket'],
+                'Key' => $key
+            ));
+        }
+
+        if ($file instanceof Core\Resource\ProcessedFile) {
+            $cacheControl = FalS3\Utility\RemoteObjectUtility::resolveCacheControlDirectivesForFile(
+                $file->getOriginalFile(),
+                true
+            );
+        } else {
+            $cacheControl = FalS3\Utility\RemoteObjectUtility::resolveCacheControlDirectivesForFile($file);
+        }
+
+        if ($cacheControl !== null
+            && $currentResource instanceof Aws\Result
+            && $currentResource->hasKey('Metadata')
+            && is_array($currentResource->get('Metadata'))
+        ) {
+            $client->copyObject(array(
+                'Bucket' => $driverConfiguration['bucket'],
+                'CacheControl' => $cacheControl,
+                'ContentType' => $currentResource->get('ContentType'),
+                'CopySource' => $driverConfiguration['bucket'] . '/' . $key,
+                'Key' => $key,
+                'Metadata' => $currentResource->get('Metadata'),
+                'MetadataDirective' => 'REPLACE'
+            ));
+        }
+    }
+}

--- a/Classes/Utility/RemoteObjectUtility.php
+++ b/Classes/Utility/RemoteObjectUtility.php
@@ -1,0 +1,145 @@
+<?php
+namespace MaxServ\FalS3\Utility;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Aws;
+use MaxServ\FalS3;
+use TYPO3\CMS\Core;
+
+/**
+ * Class RemoteObjectUtility
+ * @package MaxServ\FalS3\Utility
+ */
+class RemoteObjectUtility
+{
+    /**
+     * @var array
+     */
+    protected static $clients = [];
+
+    /**
+     * @var array
+     */
+    protected static $driverConfigurations = [];
+
+    /**
+     * @param Core\Resource\ResourceStorage $storage
+     *
+     * @return Aws\S3\S3ClientInterface|null
+     */
+    public static function resolveClientForStorage(Core\Resource\ResourceStorage $storage)
+    {
+        $client = null;
+        $storageIdentifier = $storage->getUid();
+
+        if (array_key_exists($storageIdentifier, self::$clients)) {
+            $client = self::$clients[$storageIdentifier];
+        } else if ($storage->getDriverType() === FalS3\Driver\AmazonS3Driver::DRIVER_KEY) {
+            $driverConfiguration = self::resolveDriverConfigurationForStorage($storage);
+
+            $client = new Aws\S3\S3Client(array(
+                'version' => '2006-03-01',
+                'region' => $driverConfiguration['region'],
+                'credentials' => array(
+                    'key' => $driverConfiguration['key'],
+                    'secret' => $driverConfiguration['secret']
+                )
+            ));
+
+            self::$clients[$storageIdentifier] = $client;
+        }
+
+        return $client;
+    }
+
+    /**
+     * @param Core\Resource\ResourceStorage $storage
+     *
+     * @return array
+     */
+    public static function resolveDriverConfigurationForStorage(Core\Resource\ResourceStorage $storage)
+    {
+        $driverConfiguration = array();
+        $storageIdentifier = $storage->getUid();
+
+        if (array_key_exists($storageIdentifier, self::$driverConfigurations)) {
+            $driverConfiguration = self::$driverConfigurations[$storageIdentifier];
+        } else if ($storage->getDriverType() === FalS3\Driver\AmazonS3Driver::DRIVER_KEY) {
+            $storageConfiguration = $storage->getConfiguration();
+
+            if (array_key_exists('configurationKey', $storageConfiguration)) {
+                $driverConfiguration = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fal_s3']['storageConfigurations'][$storageConfiguration['configurationKey']];
+            }
+
+            // strip the s3 protocol prefix from the bucket name
+            if (strpos($driverConfiguration['bucket'], 's3://') === 0) {
+                $driverConfiguration['bucket'] = substr($driverConfiguration['bucket'], 5);
+            }
+        }
+
+        return $driverConfiguration;
+    }
+
+    /**
+     * @param Core\Resource\AbstractFile $file
+     * @param bool $isProcessed
+     *
+     * @return string
+     */
+    public static function resolveCacheControlDirectivesForFile(Core\Resource\AbstractFile $file, $isProcessed = false)
+    {
+        $cacheControl = array();
+        $directives = null;
+
+        $configurationKey = ($isProcessed ? 'processed-file:' : 'file:') . $file->getType();
+        $driverConfiguration = self::resolveDriverConfigurationForStorage($file->getStorage());
+
+        if (array_key_exists('cacheControl', $driverConfiguration)
+            && is_array($driverConfiguration['cacheControl'])
+            && array_key_exists($configurationKey, $driverConfiguration['cacheControl'])
+        ) {
+            $directives = $driverConfiguration['cacheControl'][$configurationKey];
+        }
+
+
+        // if access is enforced trough FAL ensure that the resource isn't cached by intermediate proxies
+        $isPrivate = ($file->hasProperty('fe_groups') && !empty($file->getProperty('fe_groups')));
+
+        if (is_array($directives)
+            && ((array_key_exists('private', $directives)
+                    && $directives['private']) || $isPrivate)
+        ) {
+            $cacheControl[] = 'private';
+        }
+
+        if (is_array($directives)
+            && array_key_exists('max-age', $directives)
+            && $directives['max-age'] > 0
+        ) {
+            $cacheControl[] = 'max-age=' . (int) $directives['max-age'];
+        }
+
+        // if a no-store directive is set ignore earlier parts
+        if (is_array($directives)
+            && array_key_exists('no-store', $directives)
+            && $directives['no-store']
+        ) {
+            $cacheControl = array('no-store');
+        }
+
+        return implode(', ', $cacheControl);
+    }
+
+}


### PR DESCRIPTION
If a new file is added or the metadata indexer is triggered update the metadata of the remote S3 object. This allows you to set cache control directives like `max-age` for specific file types.

Processed files are updated by monitoring the resource storage, since the filenames contain some kind of identifier the `max-age` in the dummy configuration is set to one week.