### PR TITLE
[FEATURE] Add file filtering similar to localDriver

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -904,18 +904,18 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
      * @param int $start
      * @param int $numberOfItems
      * @param bool $recursive
-     * @param array $filenameFilterCallbacks callbacks for filtering the items
      * @param string $sort Property name used to sort the items.
      *                     Among them may be: '' (empty, no sorting), name,
      *                     fileext, size, tstamp and rw.
      *                     If a driver does not support the given property, it
      *                     should fall back to "name".
      * @param bool $sortRev TRUE to indicate reverse sorting (last to first)
+     * @param array $filenameFilterCallbacks callbacks for filtering the items
      * @return array of FileIdentifiers
      */
     public function getFilesInFolder($folderIdentifier, $start = 0, $numberOfItems = 0, $recursive = false, array $filenameFilterCallbacks = array(), $sort = '', $sortRev = false)
     {
-        $folderEntries = $this->resolveFolderEntries($folderIdentifier, $recursive, true, false);
+        $folderEntries = $this->resolveFolderEntries($folderIdentifier, $recursive, true, false, $filenameFilterCallbacks);
 
         if (!$recursive) {
             $folderEntries = $this->sortFolderEntries($folderEntries, $sort, $sortRev);
@@ -1064,12 +1064,14 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
 
     /**
      * @param string $folderIdentifier
-     * @param bool $recursive
-     * @param bool $includeFiles
-     * @param bool $includeDirectories
+     * @param bool   $recursive
+     * @param bool   $includeFiles
+     * @param bool   $includeDirectories
+     * @param array  $filterMethods
+     *
      * @return array
      */
-    protected function resolveFolderEntries($folderIdentifier, $recursive = false, $includeFiles = true, $includeDirectories = true)
+    protected function resolveFolderEntries($folderIdentifier, $recursive = false, $includeFiles = true, $includeDirectories = true, array $filterMethods = [])
     {
         $excludedFolders = isset($this->configuration['excludedFolders']) ? $this->configuration['excludedFolders'] : [];
         if (in_array($folderIdentifier, $excludedFolders)) {
@@ -1120,15 +1122,60 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
             $isDirectory = substr($entry, -1) === '/';
             if ($isDirectory && !$includeDirectories) {
                 unset($directoryEntries[$entry]);
+                $iterator->next();
+                continue;
             }
             if (!$isDirectory && !$includeFiles) {
                 unset($directoryEntries[$entry]);
+                $iterator->next();
+                continue;
             }
             $iterator->next();
+            $file = $this->getFileInfoByIdentifier($entry);
+            if(! $this->applyFilterMethodsToDirectoryItem(
+                    $filterMethods,
+                    $file['name'],
+                    $file['identifier'],
+                    $this->getParentFolderIdentifierOfIdentifier($file['identifier']))
+            ) {
+                unset($directoryEntries[$entry]);
+            }
         }
 
         $this->configuration['excludedFolders'] = $excludedFolders;
         return array_values($directoryEntries);
+    }
+
+    /**
+     * Applies a set of filter methods to a file name to find out if it should be used or not. This is e.g. used by
+     * directory listings.
+     *
+     * @param array $filterMethods The filter methods to use
+     * @param string $itemName
+     * @param string $itemIdentifier
+     * @param string $parentIdentifier
+     * @throws \RuntimeException
+     * @return bool
+     */
+    protected function applyFilterMethodsToDirectoryItem(array $filterMethods, $itemName, $itemIdentifier, $parentIdentifier)
+    {
+        foreach ($filterMethods as $filter) {
+            if (is_callable($filter)) {
+                $result = call_user_func($filter, $itemName, $itemIdentifier, $parentIdentifier, [], $this);
+                // We have to use -1 as the „don't include“ return value, as call_user_func() will return FALSE
+                // If calling the method succeeded and thus we can't use that as a return value.
+                if ($result === -1) {
+                    return false;
+                }
+                if ($result === false) {
+                    throw new \RuntimeException(
+                        'Could not apply file/folder name filter ' . $filter[0] . '::' . $filter[1],
+                        1476046425
+                    );
+                }
+            }
+        }
+        return true;
     }
 
     /**

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -904,13 +904,13 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
      * @param int $start
      * @param int $numberOfItems
      * @param bool $recursive
+     * @param array $filenameFilterCallbacks callbacks for filtering the items
      * @param string $sort Property name used to sort the items.
      *                     Among them may be: '' (empty, no sorting), name,
      *                     fileext, size, tstamp and rw.
      *                     If a driver does not support the given property, it
      *                     should fall back to "name".
      * @param bool $sortRev TRUE to indicate reverse sorting (last to first)
-     * @param array $filenameFilterCallbacks callbacks for filtering the items
      * @return array of FileIdentifiers
      */
     public function getFilesInFolder($folderIdentifier, $start = 0, $numberOfItems = 0, $recursive = false, array $filenameFilterCallbacks = array(), $sort = '', $sortRev = false)


### PR DESCRIPTION
AmazonS3Driver->getFilesInFolder() accepted param for `$filenameFilterCallbacks`but it was never used. Use the same filtering method as the LocalDriver uses.