### PR TITLE
[BUGFIX] Fix memory problems when reading large files

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -699,7 +699,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
     {
         $fileIdentifier = $this->canonicalizeAndCheckFileIdentifier($fileIdentifier);
 
-        return file_get_contents($this->getStreamWrapperPath($fileIdentifier));
+        return readfile($this->getStreamWrapperPath($fileIdentifier));
     }
 
     /**


### PR DESCRIPTION
readfile() will read the file directly into the output buffer and not into memory, allowing downloading 
 of much larger files.