### PR TITLE
[BUGFIX] Do not try to get image data for files that are not images

### DIFF
--- a/Classes/MetaData/RecordMonitor.php
+++ b/Classes/MetaData/RecordMonitor.php
@@ -58,7 +58,7 @@ class RecordMonitor
             || (
                 $file !== null
                 && $file->getType() !== AbstractFile::FILETYPE_IMAGE
-                && $file->getStorage()->getDriverType() !== AmazonS3Driver::DRIVER_KEY
+                || $file->getStorage()->getDriverType() !== AmazonS3Driver::DRIVER_KEY
             )
         ) {
             return;


### PR DESCRIPTION
Fix a logic error in a check that tests if a file is an Image before trying to get additional image metadatas. 