### PR TITLE
[BUGFIX] fix memory issue when downloading large files

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -803,11 +803,12 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
      * buffer before. Will be taken care of by the Storage.
      *
      * @param string $identifier
+     *
      * @return void
      */
     public function dumpFileContents($identifier)
     {
-        echo $this->getFileContents($identifier);
+        readfile($this->getStreamWrapperPath($this->canonicalizeAndCheckFileIdentifier($identifier)), 0);
     }
 
     /**

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -699,7 +699,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
     {
         $fileIdentifier = $this->canonicalizeAndCheckFileIdentifier($fileIdentifier);
 
-        return file_get_contents($this->getStreamWrapperPath($fileIdentifier));
+        return readfile($this->getStreamWrapperPath($fileIdentifier));
     }
 
     /**

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -699,7 +699,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
     {
         $fileIdentifier = $this->canonicalizeAndCheckFileIdentifier($fileIdentifier);
 
-        return readfile($this->getStreamWrapperPath($fileIdentifier));
+        return file_get_contents($this->getStreamWrapperPath($fileIdentifier));
     }
 
     /**


### PR DESCRIPTION
 LocalDriver uses readwhile so let's use it here as well. It directly output the contents of the file to the output buffer without reading file into memory, allowing download of much much bigger files.