### PR TITLE
Fixes keys with special characters not working

### DIFF
--- a/Classes/CacheControl/RemoteObjectUpdater.php
+++ b/Classes/CacheControl/RemoteObjectUpdater.php
@@ -153,7 +153,7 @@ class RemoteObjectUpdater
                 'Bucket' => $driverConfiguration['bucket'],
                 'CacheControl' => $cacheControl,
                 'ContentType' => $currentResource->get('ContentType'),
-                'CopySource' => $driverConfiguration['bucket'] . '/' . $key,
+                'CopySource' => $driverConfiguration['bucket'] . '/' . Aws\S3\S3Client::encodeKey($key),
                 'Key' => $key,
                 'Metadata' => $currentResource->get('Metadata'),
                 'MetadataDirective' => 'REPLACE'


### PR DESCRIPTION
Hi @arnoschoon 

We recently updated `fal_s3` from `v1.4.*` to `v1.8.*`, since the upgrade we are encountering issues with files that contain special characters such as umlauts `ä`, `ö` and `ü`. The following error is shown:

```
Error executing "CopyObject" on "https://some-portal-static.s3.eu-central-1.amazonaws.com/Webcontent/example.ch/fileadmin/_processed_/a/a/csm_Test_P%25C3%25A4ffgen_b45ad87de9.png"; 
AWS HTTP error: Client error: `PUT https://some-portal-static.s3.eu-central-1.amazonaws.com/Webcontent/example.ch/fileadmin/_processed_/a/a/csm_Test_P%25C3%25A4ffgen_b45ad87de9.png` resulted in a `404 Not Found` response: 
<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>Webcontent/example.ch/fileadmin/_p (truncated...) 
NoSuchKey (client): The specified key does not exist. - <Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>Webcontent/example.ch/fileadmin/_processed_/a/a/csm_Test_P??ffgen_b45ad87de9.png</Key>/Error>
```

We tracked the issue down to a key that should be url encoded, but is not. Please see also https://github.com/aws/aws-sdk-php/issues/379#issuecomment-60981972

Adding this encoding seems to fix our issues. I could not detect another location in the source code where this would be needed, but maybe this encoding should be used in other places as well.