### PR TITLE
CMS 9 compatibility + bugfix for fileExistsCache

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -419,6 +419,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
         }
 
         $this->flushCacheEntriesForFolder($targetFolderIdentifier);
+        unset($this->fileExistsCache[rtrim($targetFilePath, '/')]);
 
         return $targetFileIdentifier;
     }
@@ -434,6 +435,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
     {
         $parentFolderIdentifier = $this->canonicalizeAndCheckFolderIdentifier($parentFolderIdentifier);
         $targetFileIdentifier = rtrim($parentFolderIdentifier, '/') . $this->canonicalizeAndCheckFileIdentifier($fileName);
+        $absolutePath = $this->getStreamWrapperPath($targetFileIdentifier);
         $basePath = '';
 
         if (array_key_exists('basePath', $this->configuration) && !empty($this->configuration['basePath'])) {
@@ -449,6 +451,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
         ));
 
         $this->flushCacheEntriesForFolder($parentFolderIdentifier);
+        unset($this->fileExistsCache[rtrim($absolutePath, '/')]);
 
         return $targetFileIdentifier;
     }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "typo3-ter/fal_s3": "self.version"
     },
     "require": {
-        "typo3/cms-core": ">=6.2.12, <8.9.99",
+        "typo3/cms-core": ">=6.2.12, <9.5.99",
         "aws/aws-sdk-php": "^3.2.3"
     }
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = array(
     '_md5_values_when_last_written' => 'a:0:{}',
     'constraints' => array(
         'depends' => array(
-            'typo3' => '6.2.12-8.7.99',
+            'typo3' => '6.2.12-9.5.99',
         ),
         'conflicts' => array(
         ),


### PR DESCRIPTION
Fixed issue with fileExistsCache when a file was already checked before the creation of the actual file during runtime. fileExistsCache array key is unset after creation.