### PR TITLE
[BUGFIX] Set cacheConfiguration after initiating new CacheManager

### DIFF
--- a/Classes/Driver/Cache.php
+++ b/Classes/Driver/Cache.php
@@ -111,7 +111,9 @@ class Cache extends Aws\LruArrayCache
     public static function getCacheFrontend()
     {
         if (self::$cacheFrontend === null && !empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_fal_s3'])) {
-            self::$cacheFrontend = Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Cache\\CacheManager')->getCache('tx_fal_s3');
+            $cacheManager = Core\Utility\GeneralUtility::makeInstance(Core\Cache\CacheManager::class);
+            $cacheManager->setCacheConfigurations($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']);
+            self::$cacheFrontend = $cacheManager->getCache('tx_fal_s3');
         }
         return self::$cacheFrontend;
     }


### PR DESCRIPTION
If there isn't a CacheManager registered yet, you need to set the
cacheConfiguration, otherwise the cache identifier won't be found.

By setting the configuration in this method, you are sure the configuration
is loaded, before getting the cache frontend of tx_fal_s3