### PR TITLE
[Bugfix] File list showing all files when number of folder exceeds number of items (iLimit / filesPerPage) shown

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -919,6 +919,10 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
      */
     public function getFilesInFolder($folderIdentifier, $start = 0, $numberOfItems = 0, $recursive = false, array $filenameFilterCallbacks = array(), $sort = '', $sortRev = false)
     {
+        if ($start === false && $numberOfItems === false) {
+            return [];
+        }
+
         $folderEntries = $this->resolveFolderEntries($folderIdentifier, $recursive, true, false, $filenameFilterCallbacks);
 
         if (!$recursive) {
@@ -962,6 +966,10 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
      */
     public function getFoldersInFolder($folderIdentifier, $start = 0, $numberOfItems = 0, $recursive = false, array $folderNameFilterCallbacks = array(), $sort = '', $sortRev = false)
     {
+        if ($start === false && $numberOfItems === false) {
+            return [];
+        }
+
         $processingFolder = $this->getProcessingFolder();
         $excludedFolders = $this->configuration['excludedFolders'];
         $this->configuration['excludedFolders'][] = $processingFolder;


### PR DESCRIPTION
Currently there is a bug when the number of folders (e.g. 42) exceeds the limit of items shown (e.g. 40) in the file list. TYPO3 handles this special case with setting `$filesFrom=false;` and `$filesNum=false;`. (Better would probably be `$filesFrom=0;` and `$filesNum=0;`, but that's just how it is.)

See https://github.com/TYPO3/TYPO3.CMS/blob/2c8df8f59068e1861606ff1dc0f35c693ffd5393/typo3/sysext/filelist/Classes/FileList.php#L303-L306

The way `getFilesInFolder` is implemented at the moment results in showing all files for this special case, because we pass `null` as length to `array_slice`:

https://github.com/MaxServ/t3ext-fal_s3/blob/b3a0fc62b24ef514d0cd03eee82b5027fb9e9126/Classes/Driver/AmazonS3Driver.php#L928-L932

This pull request fixes the issue and makes the `fal_s3` driver behave like the local driver in the file list.