### PR TITLE
[Bugfix] Metadata updated even if no cache control has been set

### DIFF
--- a/Classes/CacheControl/RemoteObjectUpdater.php
+++ b/Classes/CacheControl/RemoteObjectUpdater.php
@@ -144,7 +144,7 @@ class RemoteObjectUpdater
             $cacheControl = FalS3\Utility\RemoteObjectUtility::resolveCacheControlDirectivesForFile($file);
         }
 
-        if ($cacheControl !== null
+        if (!empty($cacheControl)
             && $currentResource instanceof Aws\Result
             && $currentResource->hasKey('Metadata')
             && is_array($currentResource->get('Metadata'))


### PR DESCRIPTION
The variable `$cacheControl` is initialised with `null`:
https://github.com/MaxServ/t3ext-fal_s3/blob/fe076675088f2ab0ed4bae80e44474a22eb1ca92/Classes/CacheControl/RemoteObjectUpdater.php#L110

But it will always be changed to a string after one of the following methods has been called, because `implode(',', [])` returns an empty string instead of `null`.
https://github.com/MaxServ/t3ext-fal_s3/blob/fe076675088f2ab0ed4bae80e44474a22eb1ca92/Classes/CacheControl/RemoteObjectUpdater.php#L138-L145

Thus the following condition is not working to check whether metadata should be updated or not.
https://github.com/MaxServ/t3ext-fal_s3/blob/fe076675088f2ab0ed4bae80e44474a22eb1ca92/Classes/CacheControl/RemoteObjectUpdater.php#L147-L151

I changed the condition to `!empty($cacheControl)`, which detects `null` as well as empty strings.