### PR TITLE
[BUGFIX] - Only update storage metadata in case of changes

### DIFF
--- a/Classes/CacheControl/RemoteObjectUpdater.php
+++ b/Classes/CacheControl/RemoteObjectUpdater.php
@@ -148,6 +148,8 @@ class RemoteObjectUpdater
             && $currentResource instanceof Aws\Result
             && $currentResource->hasKey('Metadata')
             && is_array($currentResource->get('Metadata'))
+            && $currentResource->hasKey('CacheControl')
+            && strcmp($currentResource->get('CacheControl'), $cacheControl) !== 0
         ) {
             $client->copyObject(array(
                 'Bucket' => $driverConfiguration['bucket'],


### PR DESCRIPTION
This patch adds a check if the local cache-control directive isn't already set remotely so we can skip `copyObject`. This should fix the race condition discussed in https://github.com/MaxServ/t3ext-fal_s3/issues/49