### PR TITLE
Remove rtrim in folder exists pathname

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -370,10 +370,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
     {
         $folderIdentifier = $this->canonicalizeAndCheckFolderIdentifier($folderIdentifier);
 
-        $path = rtrim(
-            $this->getStreamWrapperPath($folderIdentifier),
-            '/'
-        );
+        $path = $this->getStreamWrapperPath($folderIdentifier);
 
         if (!array_key_exists($path, $this->folderExistsCache)) {
             $this->folderExistsCache[$path] = is_dir($path);


### PR DESCRIPTION
Remove rtrim in folderExists method to prevent files with the same name as folder to cause problems with storageMounts for users.