### PR TITLE
[Bugfix] Fixes folderCreateMask read from old configuration path

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -279,7 +279,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
         }
         $path = $this->getStreamWrapperPath($identifier);
 
-        mkdir($path, $GLOBALS['TYPO3_CONF_VARS']['BE']['folderCreateMask'], $recursive);
+        mkdir($path, octdec($GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask']), $recursive);
 
         $this->flushCacheEntriesForFolder($parentFolderIdentifier);
 
@@ -675,7 +675,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
 
                 // use mkdir to create a new directory instead of copying the resource
             if (substr($sourcePath, -1) === '/') {
-                mkdir($targetPath, $GLOBALS['TYPO3_CONF_VARS']['BE']['folderCreateMask'], true);
+                mkdir($targetPath, octdec($GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask']), true);
             } else {
                 copy($sourcePath, $targetPath);
             }


### PR DESCRIPTION
The setting `folderCreateMask` should be read from `$GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask']`:

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/7.6/Important-36166-MoveAccessRightParametersFromBEToSYSConfiguration.html

I implemented it the same way TYPO3 does it in `GeneralUtility`:

https://github.com/TYPO3/TYPO3.CMS/blob/630f7c168f64d7fa045ac7f76af01f6381f1997b/typo3/sysext/core/Classes/Utility/GeneralUtility.php#L1989