### PR TITLE
[TASK] Fix mkdir not working reliable with S3 ACL calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+### Fixed
+- mkdir not working reliable with the octdec permissions, let S3 determine the permissions (ACL) inside the StreamWrapper
+
 ## [1.12.0] - 2021-12-07
 ### Added
 - Extractor for extracting metadata used by Indexer

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -316,7 +316,14 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
         }
         $path = $this->getStreamWrapperPath($identifier);
 
-        mkdir($path, octdec($GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask']), $recursive);
+        /**
+         * We do not care about the directory permissions by ourselves, but let the Amazon S3 StreamWrapper for
+         * mkdir decide the correct ACL for the directory. The StreamWrapper will execute decoct() with the
+         * permissions value. If we set it to null or 0, it will output 0 and will go with the default ACL set.
+         * The value null can not be used because it will throw errors when PHP is set to strict types.
+         * @see https://github.com/aws/aws-sdk-php/blob/master/src/S3/StreamWrapper.php#L873-L880
+         */
+        mkdir($path, 0, $recursive);
 
         $this->flushCacheEntriesForFolder($parentFolderIdentifier);
 
@@ -733,7 +740,14 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
 
             // use mkdir to create a new directory instead of copying the resource
             if (substr($sourcePath, -1) === '/') {
-                mkdir($targetPath, octdec($GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask']), true);
+                /**
+                 * We do not care about the directory permissions by ourselves, but let the Amazon S3 StreamWrapper for
+                 * mkdir decide the correct ACL for the directory. The StreamWrapper will execute decoct() with the
+                 * permissions value. If we set it to null or 0, it will output 0 and will go with the default ACL.
+                 * The value null can not be used because it will throw errors when PHP is set to strict types.
+                 * @see https://github.com/aws/aws-sdk-php/blob/master/src/S3/StreamWrapper.php#L873-L880
+                 */
+                mkdir($targetPath, 0, true);
             } else {
                 copy($sourcePath, $targetPath);
             }


### PR DESCRIPTION
Fix mkdir not working with octdec value, let S3 determine permissions (ACL) inside the S3 StreamWrapper for the mkdir method.

Before, in versions lower than 1.10, the mkdir method was passing `null` to the mkdir method by accident (TYPO3 core changed the configuration path) and during that time, the Amazon S3 StreamWrapper was determing the permissions (and corresponding ACL) by itself. In version 1.10 and higher, the path to the TYPO3 configuration value has been fixed and wrapped the value in octdec which made the StreamWrapper incorrectly determine the correct permissions and correcsponding ACL.

With this change, the mkdir method will receive `0`. This prevents strict type issues, because mkdir expects an integer as permissions argument. `null` and `0` will both let the StreamWrapper determine the correct ACL.