### PR TITLE
Add suggestion for causal/extractor for extended metadata extraction

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -835,10 +835,6 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
      */
     public function getFileForLocalProcessing($fileIdentifier, $writable = true)
     {
-        if (isset($this->temporaryFiles[$fileIdentifier])) {
-            return $this->temporaryFiles[$fileIdentifier];
-        }
-
         $fileIdentifier = $this->canonicalizeAndCheckFileIdentifier($fileIdentifier);
         $temporaryFilePath = $this->getTemporaryPathForFile($fileIdentifier);
         $path = $this->getStreamWrapperPath($fileIdentifier);

--- a/Classes/Service/Extraction/ExifToolMetadataExtraction.php
+++ b/Classes/Service/Extraction/ExifToolMetadataExtraction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MaxServ\FalS3\Service\Extraction;
+
+use MaxServ\FalS3\Driver\AmazonS3Driver;
+
+/**
+ * Class ExifToolMetadataExtraction
+ */
+class ExifToolMetadataExtraction extends \Causal\Extractor\Service\Extraction\ExifToolMetadataExtraction
+{
+    /**
+     * Returns all supported DriverTypes.
+     *
+     * Since some processors may only work for local files, and other
+     * are especially made for processing files from remote.
+     *
+     * Returns array of strings with driver names of Drivers which are supported,
+     * If the driver did not register a name, it's the class name.
+     * empty array indicates no restrictions.
+     *
+     * @return array
+     */
+    public function getDriverRestrictions(): array
+    {
+        return array_merge_recursive(
+            parent::getDriverRestrictions(),
+            [
+                AmazonS3Driver::DRIVER_KEY
+            ]
+        );
+    }
+}

--- a/Classes/Service/Extraction/ImageDimensionsExtraction.php
+++ b/Classes/Service/Extraction/ImageDimensionsExtraction.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MaxServ\FalS3\Index;
+namespace MaxServ\FalS3\Service\Extraction;
 
 use MaxServ\FalS3\Driver\AmazonS3Driver;
 use TYPO3\CMS\Core\Resource\File;
@@ -10,9 +10,9 @@ use TYPO3\CMS\Core\Type\File\ImageInfo;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * Class Extractor
+ * Class ImageDimensionsExtraction
  */
-class Extractor implements ExtractorInterface
+class ImageDimensionsExtraction implements ExtractorInterface
 {
 
     /**

--- a/Classes/Service/Extraction/PdfinfoMetadataExtraction.php
+++ b/Classes/Service/Extraction/PdfinfoMetadataExtraction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MaxServ\FalS3\Service\Extraction;
+
+use MaxServ\FalS3\Driver\AmazonS3Driver;
+
+/**
+ * Class PdfinfoMetadataExtraction
+ */
+class PdfinfoMetadataExtraction extends \Causal\Extractor\Service\Extraction\PdfinfoMetadataExtraction
+{
+    /**
+     * Returns all supported DriverTypes.
+     *
+     * Since some processors may only work for local files, and other
+     * are especially made for processing files from remote.
+     *
+     * Returns array of strings with driver names of Drivers which are supported,
+     * If the driver did not register a name, it's the class name.
+     * empty array indicates no restrictions.
+     *
+     * @return array
+     */
+    public function getDriverRestrictions(): array
+    {
+        return array_merge_recursive(
+            parent::getDriverRestrictions(),
+            [
+                AmazonS3Driver::DRIVER_KEY
+            ]
+        );
+    }
+}

--- a/Classes/Service/Extraction/PhpMetadataExtraction.php
+++ b/Classes/Service/Extraction/PhpMetadataExtraction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MaxServ\FalS3\Service\Extraction;
+
+use MaxServ\FalS3\Driver\AmazonS3Driver;
+
+/**
+ * Class PhpMetadataExtraction
+ */
+class PhpMetadataExtraction extends \Causal\Extractor\Service\Extraction\PhpMetadataExtraction
+{
+    /**
+     * Returns all supported DriverTypes.
+     *
+     * Since some processors may only work for local files, and other
+     * are especially made for processing files from remote.
+     *
+     * Returns array of strings with driver names of Drivers which are supported,
+     * If the driver did not register a name, it's the class name.
+     * empty array indicates no restrictions.
+     *
+     * @return array
+     */
+    public function getDriverRestrictions(): array
+    {
+        return array_merge_recursive(
+            parent::getDriverRestrictions(),
+            [
+                AmazonS3Driver::DRIVER_KEY
+            ]
+        );
+    }
+}

--- a/Classes/Service/Extraction/TikaLanguageDetector.php
+++ b/Classes/Service/Extraction/TikaLanguageDetector.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MaxServ\FalS3\Service\Extraction;
+
+use MaxServ\FalS3\Driver\AmazonS3Driver;
+
+/**
+ * Class TikaLanguageDetector
+ */
+class TikaLanguageDetector extends \Causal\Extractor\Service\Extraction\TikaLanguageDetector
+{
+    /**
+     * Returns all supported DriverTypes.
+     *
+     * Since some processors may only work for local files, and other
+     * are especially made for processing files from remote.
+     *
+     * Returns array of strings with driver names of Drivers which are supported,
+     * If the driver did not register a name, it's the class name.
+     * empty array indicates no restrictions.
+     *
+     * @return array
+     */
+    public function getDriverRestrictions(): array
+    {
+        return array_merge_recursive(
+            parent::getDriverRestrictions(),
+            [
+                AmazonS3Driver::DRIVER_KEY
+            ]
+        );
+    }
+}

--- a/Classes/Service/Extraction/TikaMetadataExtraction.php
+++ b/Classes/Service/Extraction/TikaMetadataExtraction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MaxServ\FalS3\Service\Extraction;
+
+use MaxServ\FalS3\Driver\AmazonS3Driver;
+
+/**
+ * Class TikaMetadataExtraction
+ */
+class TikaMetadataExtraction extends \Causal\Extractor\Service\Extraction\TikaMetadataExtraction
+{
+    /**
+     * Returns all supported DriverTypes.
+     *
+     * Since some processors may only work for local files, and other
+     * are especially made for processing files from remote.
+     *
+     * Returns array of strings with driver names of Drivers which are supported,
+     * If the driver did not register a name, it's the class name.
+     * empty array indicates no restrictions.
+     *
+     * @return array
+     */
+    public function getDriverRestrictions(): array
+    {
+        return array_merge_recursive(
+            parent::getDriverRestrictions(),
+            [
+                AmazonS3Driver::DRIVER_KEY
+            ]
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
     "require-dev": {
         "nimut/testing-framework": "^4.1 || ^5.1"
     },
+    "suggest": {
+        "causal/extractor": "^2.0"
+    },
     "config": {
         "sort-packages": true
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,6 +12,9 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '6.2.12-10.4.99',
+        ],
+        'suggests' => [
+            'extractor' => '2.0.0-2.99.99'
         ]
     ]
 ];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -120,6 +120,27 @@ call_user_func(function () {
     \TYPO3\CMS\Core\Resource\Index\ExtractorRegistry::getInstance()
         ->registerExtractionService(\MaxServ\FalS3\Index\Extractor::class);
 
+    if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('extractor')) {
+        // phpcs:disable
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\Causal\Extractor\Service\Extraction\PhpMetadataExtraction::class] = [
+            'className' => \MaxServ\FalS3\Service\Extraction\PhpMetadataExtraction::class
+        ];
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\Causal\Extractor\Service\Extraction\ExifToolMetadataExtraction::class] = [
+            'className' => \MaxServ\FalS3\Service\Extraction\ExifToolMetadataExtraction::class
+        ];
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\Causal\Extractor\Service\Extraction\PdfinfoMetadataExtraction::class] = [
+            'className' => \MaxServ\FalS3\Service\Extraction\PdfinfoMetadataExtraction::class
+        ];
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\Causal\Extractor\Service\Extraction\TikaMetadataExtraction::class] = [
+            'className' => \MaxServ\FalS3\Service\Extraction\TikaMetadataExtraction::class
+        ];
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\Causal\Extractor\Service\Extraction\TikaLanguageDetector::class] = [
+            'className' => \MaxServ\FalS3\Service\Extraction\TikaLanguageDetector::class
+        ];
+        // phpcs:enable
+    }
+
+
     if (class_exists(\TYPO3\CMS\Core\Information\Typo3Version::class)) {
         $typo3Branch = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
             \TYPO3\CMS\Core\Information\Typo3Version::class

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -118,7 +118,7 @@ call_user_func(function () {
 
     // register extractor
     \TYPO3\CMS\Core\Resource\Index\ExtractorRegistry::getInstance()
-        ->registerExtractionService(\MaxServ\FalS3\Index\Extractor::class);
+        ->registerExtractionService(\MaxServ\FalS3\Service\Extraction\ImageDimensionsExtraction::class);
 
     if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('extractor')) {
         // phpcs:disable


### PR DESCRIPTION
With this adjustment, an optional dependency has been added for the [causal/extractor](https://github.com/xperseguers/t3ext-extractor) extension to enrich the metadata that is being added to the TYPO3 metadata tables.

This way, additional data other than image dimensions and the default metadata can be extracted too while uploading or replacing files in the file admin.

The extractor Extraction classes have been XClasses because the could not be extended by using the Extbase object container, and the possible drivers can not be configured manually from within the extensions configuration.

Besides the adjustment for the XClasses Extraction services, the already implemented extractor has been renamed and moved to the Service/Extraction namespace and has been renamed to ImageDimensionsExtractor.

Also a minor bug has been fixed in which the getFileForLocalProcessing returned an incorrect value for a requested file. Instead of the temporary file, it was refering to a `/tmp/phpXYZ` file which was causing issues with metadata extraction. With this adjustment, we force to copy and use the real file for file extraction.

We might have to discuss what version we will tag this update to. Is it another feature release, or should we make this a breaking change if someone extends the Extractor class? And besides that, we might have to look if we still support TYPO3 v6 and up, or that we should change this dependency too and make this a major release.