### PR TITLE
Make endpoint and endpoint style configurable

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -185,7 +185,13 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
         // Custom client endpoint. If set, apply the custom endpoint
         if (isset($this->configuration['endpoint']) && is_string($this->configuration['endpoint'])) {
             $clientConfiguration['endpoint'] = $this->configuration['endpoint'];
-            $clientConfiguration['use_path_style_endpoint'] = true;
+        }
+
+        if (
+            isset($this->configuration['use_path_style_endpoint'])
+            && is_bool($this->configuration['use_path_style_endpoint'])
+        ) {
+            $clientConfiguration['use_path_style_endpoint'] = $this->configuration['use_path_style_endpoint'];
         }
 
         $this->s3Client = new S3Client($clientConfiguration);


### PR DESCRIPTION
To make this extension work with third party S3 object storage compatible providers, the endpoint should be configurable from within the configuration. Besides the endpoint, also the `use_path_style_endpoint` option should be configurable, which prevents that the AmazonClient will try to create an Amazon-like endpoint.

Some third-party providers do not use a region setting, so the region can be empty. The AmazonClient requires a region, however it may be an empty string (is it a non-nullable of type string)

The configuration reading has been simplified and made better readable by using early exit statements instead of nested if-else statements.

The code has been refactored with PHP 5.6 support in mind for TYPO3 v6.2, however as stated in pull request #62, we should decide if we still support ad want to support TYPO3 v6, or that we should focus on higher versions with an updated PHP version constraint to a minumum of php 7.0