### PR TITLE
[FEATURE] Use caches for file and folder count methods in driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,28 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2022-09-30
+
+### Added
+
+- Caching to `countFilesInFolder` and `countFoldersInFolder` methods
+
 ## [1.13.3] - 2022-09-07
+
 ### Fixed
+
 - Prevent filelist exception when a directory contains a file of type 'Octet-stream' + directory with the same name
 
 ## [1.13.2] - 2022-08-05
+
 ### Fixed
-- Partly reverted 1.13.1, since it caused performance issues. The calls to `is_file` in `AmazonS3Driver::fileExists` were cached by the StreamWrapper (`StreamWrapper::url_stat`). HeadObject calls however are not cached.
+
+- Partly reverted 1.13.1, since it caused performance issues. The calls to `is_file` in `AmazonS3Driver::fileExists`
+  were cached by the StreamWrapper (`StreamWrapper::url_stat`). HeadObject calls however are not cached.
 
 ## [1.13.1] - 2022-06-20
 ### Fixed

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1185,7 +1185,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
         );
 
         $count = Cache::getCacheFrontend()->get($cacheEntryIdentifier);
-        if (!$count) {
+        if ($count === false) {
             $count = count($this->getFilesInFolder($folderIdentifier, 0, 0, $recursive, $filenameFilterCallbacks));
             $cacheTags = [Cache::buildEntryIdentifier($path, 'd')];
             Cache::getCacheFrontend()->set($cacheEntryIdentifier, $count, $cacheTags, 0);
@@ -1215,7 +1215,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
         );
 
         $count = Cache::getCacheFrontend()->get($cacheEntryIdentifier);
-        if (!$count) {
+        if ($count === false) {
             $count = count($this->getFoldersInFolder($folderIdentifier, 0, 0, $recursive, $folderNameFilterCallbacks));
             $cacheTags = [Cache::buildEntryIdentifier($path, 'd')];
             Cache::getCacheFrontend()->set($cacheEntryIdentifier, $count, $cacheTags, 0);

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1176,8 +1176,24 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
      */
     public function countFilesInFolder($folderIdentifier, $recursive = false, array $filenameFilterCallbacks = [])
     {
-        return count($this->getFilesInFolder($folderIdentifier, 0, 0, $recursive, $filenameFilterCallbacks));
+        $folderIdentifier = $this->canonicalizeAndCheckFolderIdentifier($folderIdentifier);
+        $path = $this->getStreamWrapperPath($folderIdentifier);
+
+        $cacheEntryIdentifier = Cache::buildEntryIdentifier(
+            $path,
+            'count_files'
+        );
+
+        $count = Cache::getCacheFrontend()->get($cacheEntryIdentifier);
+        if (!$count) {
+            $count = count($this->getFilesInFolder($folderIdentifier, 0, 0, $recursive, $filenameFilterCallbacks));
+            $cacheTags = [Cache::buildEntryIdentifier($path, 'd')];
+            Cache::getCacheFrontend()->set($cacheEntryIdentifier, $count, $cacheTags, 0);
+        }
+
+        return (int)$count;
     }
+
 
     /**
      * Returns the number of folders inside the specified path
@@ -1190,7 +1206,22 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
      */
     public function countFoldersInFolder($folderIdentifier, $recursive = false, array $folderNameFilterCallbacks = [])
     {
-        return count($this->getFoldersInFolder($folderIdentifier, 0, 0, $recursive, $folderNameFilterCallbacks));
+        $folderIdentifier = $this->canonicalizeAndCheckFolderIdentifier($folderIdentifier);
+        $path = $this->getStreamWrapperPath($folderIdentifier);
+
+        $cacheEntryIdentifier = Cache::buildEntryIdentifier(
+            $path,
+            'count_folders'
+        );
+
+        $count = Cache::getCacheFrontend()->get($cacheEntryIdentifier);
+        if (!$count) {
+            $count = count($this->getFoldersInFolder($folderIdentifier, 0, 0, $recursive, $folderNameFilterCallbacks));
+            $cacheTags = [Cache::buildEntryIdentifier($path, 'd')];
+            Cache::getCacheFrontend()->set($cacheEntryIdentifier, $count, $cacheTags, 0);
+        }
+
+        return (int)$count;
     }
 
     /**


### PR DESCRIPTION
The `countFilesInFolder` and `countFoldersInFolder` methods in the driver class were heavy and had to be executed everytime someone opened a folder.

The file and folder counts are being used in the filelist module to show the number of subfiles and -folders.

Without using the caching mechanism in the count methods, the driver had to fetch all files folders from S3 of the S3 caches, and count the result. When using the cache, the count will only be calculated once and fetched from cache.

By setting the cache tags equal to the cache tag set by the `CachedDirectoryIterator` for a directory, whe count caches will be cleared when a file or folder is being added, changed or removed from within the filelist.

An edge-case where incorrect counts are being saved, could occur if files or folders are being manipulated outside of TYPO3.