### PR TITLE
Bugfix/t3xfs3-13 fix middleware name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- use correct middleware name instead of a copied docs example
+
 ## [2.1.0] - 2023-07-31
 ### Added
 - FalS3PreconnectMiddleware that automatically adds preconnect headers for online S3 storages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - use correct middleware name instead of a copied docs example
+- file name sanitization was too strict, we now allow more special characters
 
 ## [2.1.0] - 2023-07-31
 ### Added

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1395,12 +1395,15 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      * @return string
      * @throws InvalidFileNameException
      */
-    public function sanitizeFileName($fileName, $charset = '')
+    public function sanitizeFileName($fileName, $charset = 'utf-8')
     {
-        // Allow letters, numbers, underscores, dashes, dots, parentheses and spaces.
-        // Replace all other characters with an underscore.
-        $cleanFileName = (string)preg_replace('/[^a-zA-Z0-9\-\._() ]/', '_', trim($fileName));
+        if ($charset === 'utf-8') {
+            $fileName = \Normalizer::normalize((string)$fileName) ?: $fileName;
+        }
 
+        // Unlike the LocalDriver, we don't need an exception for UTF-8 here since we use S3 as storage.
+        // Strip the filename from unwanted characters, replace them with an underscore
+        $cleanFileName = (string)preg_replace('/[#$%^&*+=\[\]\'`;,\/{}|":<>?~\\\\]/', '_', trim($fileName));
         $cleanFileName = rtrim($cleanFileName, '.');
         if ($cleanFileName === '') {
             throw new InvalidFileNameException(

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -2,7 +2,7 @@
 
 return [
     'frontend' => [
-        'middleware-identifier' => [
+        'maxserv/fal_s3/preconnect' => [
             'target' => \MaxServ\FalS3\Middleware\FalS3PreconnectMiddleware::class,
             'before' => [
                 'typo3/cms-frontend/content-length-headers',


### PR DESCRIPTION
Fixed
- use correct middleware name instead of a copied docs example
- file name sanitization was too strict, we now allow more special characters