### PR TITLE
[BUGFIX] afterFileProcessing event exits early if the processed file is the same as the original file.

### DIFF
--- a/Classes/Driver/CachedDirectoryIterator.php
+++ b/Classes/Driver/CachedDirectoryIterator.php
@@ -165,7 +165,7 @@ class CachedDirectoryIterator implements \RecursiveIterator, \SeekableIterator
     /**
      * @see Iterator::key()
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->currentIndex;
     }
@@ -173,7 +173,7 @@ class CachedDirectoryIterator implements \RecursiveIterator, \SeekableIterator
     /**
      * @see Iterator::current()
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->filesAndFolders[$this->currentIndex];
     }

--- a/Classes/Resource/Event/RemoteObjectUpdateEvent.php
+++ b/Classes/Resource/Event/RemoteObjectUpdateEvent.php
@@ -61,7 +61,7 @@ class RemoteObjectUpdateEvent
      */
     public function afterFileProcessing(AfterFileProcessingEvent $event): void
     {
-        if (!$event->getProcessedFile()->exists()) {
+        if (!$event->getProcessedFile()->exists() || $event->getProcessedFile()->usesOriginalFile()) {
             return;
         }
 


### PR DESCRIPTION
If you store files on Amazon S3 but process them through fileadmin, you may run into an issue with some file types (like MP4), where TYPO3 backend no longer loads records that reference those files.

$event->getProcessedFile->exists() WILL return true when "userOriginalFile()" is true. I think this is true for all files that don't get procedded, can someone verify? 

If processed folder is not on the same storage as the origiginal file, then the followup getStorage()->getFileInfoByIdentifier() will not find the file and will return an error.
