### PR TITLE
[BUGFIX] Prevent undefined array key access

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -434,7 +434,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
         );
 
         /** @var \TYPO3\CMS\Core\Http\ServerRequest $request */
-        $request = $GLOBALS['TYPO3_REQUEST'];
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
         $modifyingRequestMethods = ['POST', 'PUT', 'DELETE', 'PATCH'];
         // Prevent duplicate calls to redis (e.g. in the filelist, which calls fileExists _a lot_ for the same file)
         // by caching the result in memory.

--- a/Classes/Resource/Event/FlushCacheActionEvent.php
+++ b/Classes/Resource/Event/FlushCacheActionEvent.php
@@ -42,7 +42,7 @@ class FlushCacheActionEvent
     protected function isCacheItemAvailable(): bool
     {
         return $this->getBackendUser()->isAdmin()
-            || $this->getBackendUser()->getTSConfig()['options.']['clearCache.'][self::ITEM_KEY] ?? false;
+            || ($this->getBackendUser()->getTSConfig()['options.']['clearCache.'][self::ITEM_KEY] ?? false);
     }
 
     /**


### PR DESCRIPTION
Class `FlushCacheActionEvent` tries to take care of undefined array key access, but due to operator precedence the coalesce operator does not prevent it. Adding brackets takes care of the issue.